### PR TITLE
Add do{Sync,Async,AsyncWithMessage} methods to gutiBot

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,8 @@
 
 const express = require("express");
 const bodyParser = require("body-parser");
+
+const gutibot = require("./gutiBot");
 const barelyBot = require("./barelyBot").bot;
 const defineBot = require("./defineBot");
 
@@ -14,7 +16,7 @@ app.get('/', (req, res) => {
   res.send('Hello! This is gutibot. Are you lost?');
 });
 
-app.post("/doesheknower", barelyBot);
+app.post("/doesheknower", gutibot.doSync(barelyBot));
 app.post("/define", defineBot);
 
 app.use((err, req, res, next) => {

--- a/src/barelyBot.js
+++ b/src/barelyBot.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const gutiBot = require('./gutiBot');
 const slack = require('./utils/slackUtils');
 const strUtils = require('./utils/stringUtils');
 
@@ -42,14 +41,14 @@ function _shouldRespond(username, matches) {
     && _isTwentyFivePercentChance();
 }
 
-function bot(req, res) {
-  const text = req.body.text;
-  const username = req.body.user_name;
+function bot(request, respondOk, respondWith) {
+  const text = request.body.text;
+  const username = request.body.user_name;
   const matches = _cleanMatches(getMatches(text));
   const linkify = strUtils.linkifySlackUsername;
 
   if (!_shouldRespond(username, matches)) {
-    return gutiBot.respondOk(res);
+    return respondOk();
   }
 
   const blankEr = matches
@@ -59,7 +58,7 @@ function bot(req, res) {
 
   const message = `${linkify(username)}: ${blankEr}?! I barely know 'er!`;
 
-  return gutiBot.respondWith(res, message);
+  return respondWith(message);
 }
 
 module.exports = {

--- a/src/gutiBot.js
+++ b/src/gutiBot.js
@@ -15,11 +15,11 @@ function _getBotUserApiToken() {
   return process.env.SLACK_BOT_USER_API_TOKEN;
 }
 
-function respondOk(response) {
+function _respondOk(response) {
   return _ok(response).end();
 }
 
-function respondWith(response, message) {
+function _respondOkWithMessage(response, message) {
   const payload = slack.outgoingWebhook.createResponse(message);
 
   return _ok(response).json(payload);
@@ -39,9 +39,39 @@ function respondViaDefaultWebhook(destination, message) {
   return respondViaWebhook(hookUrl, destination, message);
 }
 
+function doSync(botFn) {
+  return (request, response) => {
+    return botFn(
+      request,
+      () => _respondOk(response),
+      message => _respondOkWithMessage(response, message)
+    );
+  };
+}
+
+// NOTE: Neither of the following `doAsync` functions has been tested, so should
+// be considered suspect for the time-being
+
+function doAsync(botFn) {
+  return (request, response) => {
+    botFn(request);
+    return respondOk(response);
+  };
+}
+
+function doAsyncWithMessage(botFn, message) {
+  return (request, response) => {
+    botFn(request);
+    return respondWith(response, message);
+  };
+}
+
+// ============================================================================
+
 module.exports = {
-  respondOk,
-  respondWith,
+  doAsync,
+  doAsyncWithMessage,
   respondViaWebhook,
   respondViaDefaultWebhook,
+  doSync,
 };


### PR DESCRIPTION
We can now more strictly enforce the following separation:
* gutiBot handles responding to Slack
* `*Bot` decides what to say